### PR TITLE
[bug fix] wait_receive

### DIFF
--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -287,11 +287,11 @@ static int wait_receive(CefT_Client_Handle handler, int timeout_ms, int error_on
 MILESTONE
     int res = 0;
     int tryn = 0;
-    int waittime = 1;
+    int waittime = 1000;
     int elapsedtime = 0;
     int timeout_us;
 
-    if (timeout_ms < 0) { timeout_us = CefpycoC_Default_Timeout * 1; }
+    if (timeout_ms < 0) { timeout_us = CefpycoC_Default_Timeout * 1000; }
     else { timeout_us = timeout_ms * 1000; }
 
     if (handler < 1) return exit_with_error_msg(handler, "Handle must be created.");
@@ -299,7 +299,7 @@ MILESTONE
     if (res) return res;
     while (1) {
 		res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
-        elapsedtime += 1000; // read takes 1 sec from cefore-0.8.2.2
+        elapsedtime += 1000000; // read takes 1 sec from cefore-0.8.2.2
         if (res > 0) break;
 		if (elapsedtime >= timeout_us) { // 13-tries take 1s, 18-tries take 4s
             if (error_on_timeout) {
@@ -313,8 +313,8 @@ MILESTONE
             }
 		}
         sleep(1);
-        elapsedtime += waittime * 1000;
-        waittime += tryn * tryn;
+        elapsedtime += waittime;
+        waittime += 500 * tryn * tryn;
         tryn++;
 	}
     return res;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -298,10 +298,10 @@ MILESTONE
     res = cpc_buf_remains();
     if (res) return res;
     while (1) {
-		res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
+	res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
         elapsedtime += 1000000; // read takes 1 sec from cefore-0.8.2.2
         if (res > 0) break;
-		if (elapsedtime >= timeout_us) { // 13-tries take 1s, 18-tries take 4s
+	if (elapsedtime >= timeout_us) { // 13-tries take 1s, 18-tries take 4s
             if (error_on_timeout) {
                 if (cefpyco_enable_log) {
         			cef_log_write(CefC_Log_Info, 
@@ -312,7 +312,7 @@ MILESTONE
                 return 0;
             }
 		}
-        sleep(1);
+        sleep(int(waittime/1000));
         elapsedtime += waittime;
         waittime += 500 * tryn * tryn;
         tryn++;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -32,6 +32,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <ctype.h>
+#include "Python.h"
 
 #include "cefpyco_util.h"
 #include "cefpyco_parse.h"
@@ -308,15 +309,16 @@ MILESTONE
                         "\033[101m*** [CAUTION] Stop to wait. ***\033[0m\n");
                 }
     		return -1;
-            } else {
-            	return 0;
-            }
-	}
-	printf("%d\n", waittime);
-        sleep(1);
-        elapsedtime += waittime;
-        waittime += 500 * tryn * tryn;
-        tryn++;
+            	} else {
+            		return 0;
+            	}
+	    }
+	    Py_BEGIN_ALLOW_THREADS
+	    printf("%d\n", waittime);
+	    sleep(1);
+	    elapsedtime += waittime;
+	    waittime += 500 * tryn * tryn;
+	    tryn++;
 	}
     return res;
 }

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -313,9 +313,13 @@ MILESTONE
             		return 0;
             	}
 	    }
-	    Py_BEGIN_ALLOW_THREADS
+	    
 	    printf("%d\n", waittime);
+	    
+	    Py_BEGIN_ALLOW_THREADS
 	    sleep(1);
+	    Py_END_ALLOW_THREADS
+		    
 	    elapsedtime += waittime;
 	    waittime += 500 * tryn * tryn;
 	    tryn++;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -287,11 +287,11 @@ static int wait_receive(CefT_Client_Handle handler, int timeout_ms, int error_on
 MILESTONE
     int res = 0;
     int tryn = 0;
-    int waittime = 1000;
+    int waittime = 1;
     int elapsedtime = 0;
     int timeout_us;
 
-    if (timeout_ms < 0) { timeout_us = CefpycoC_Default_Timeout * 1000; }
+    if (timeout_ms < 0) { timeout_us = CefpycoC_Default_Timeout * 1; }
     else { timeout_us = timeout_ms * 1000; }
 
     if (handler < 1) return exit_with_error_msg(handler, "Handle must be created.");
@@ -299,7 +299,7 @@ MILESTONE
     if (res) return res;
     while (1) {
 		res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
-        elapsedtime += 1000000; // read takes 1 sec from cefore-0.8.2.2
+        elapsedtime += 1000; // read takes 1 sec from cefore-0.8.2.2
         if (res > 0) break;
 		if (elapsedtime >= timeout_us) { // 13-tries take 1s, 18-tries take 4s
             if (error_on_timeout) {
@@ -312,9 +312,9 @@ MILESTONE
                 return 0;
             }
 		}
-        usleep(waittime);
-        elapsedtime += waittime;
-        waittime += 500 * tryn * tryn;
+        sleep(waittime);
+        elapsedtime += waittime * 1000;
+        waittime += tryn * tryn;
         tryn++;
 	}
     return res;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -298,7 +298,7 @@ MILESTONE
     res = cpc_buf_remains();
     if (res) return res;
     while (1) {
-	// res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
+	res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
         elapsedtime += 1000000; // read takes 1 sec from cefore-0.8.2.2
         if (res > 0) break;
 	if (elapsedtime >= timeout_us) { // 13-tries take 1s, 18-tries take 4s
@@ -309,11 +309,11 @@ MILESTONE
                 }
     		return -1;
             } else {
-                return 0;
+            	return 0;
             }
 	}
 	printf("%d\n", waittime);
-        sleep((int) waittime/1000);
+        sleep(1);
         elapsedtime += waittime;
         waittime += 500 * tryn * tryn;
         tryn++;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -304,14 +304,15 @@ MILESTONE
 	if (elapsedtime >= timeout_us) { // 13-tries take 1s, 18-tries take 4s
             if (error_on_timeout) {
                 if (cefpyco_enable_log) {
-        			cef_log_write(CefC_Log_Info, 
+        		cef_log_write(CefC_Log_Info, 
                         "\033[101m*** [CAUTION] Stop to wait. ***\033[0m\n");
                 }
-    			return -1;
+    		return -1;
             } else {
                 return 0;
             }
-		}
+	}
+	printf("%d\n", waittime);
         sleep((int) waittime/1000);
         elapsedtime += waittime;
         waittime += 500 * tryn * tryn;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -300,7 +300,7 @@ MILESTONE
     if (res) return res;
 
     while (1) {
-        Py_BEGIN_ALLOW_THREADS
+        // Py_BEGIN_ALLOW_THREADS
 	    res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
         elapsedtime += 1000000; // read takes 1 sec from cefore-0.8.2.2
         if (res > 0) break;
@@ -315,6 +315,7 @@ MILESTONE
                 return 0;
             }
         }
+        Py_BEGIN_ALLOW_THREADS
         usleep(waittime);
         Py_END_ALLOW_THREADS
 

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -316,13 +316,13 @@ MILESTONE
             }
         }
         usleep(waittime);
-        PyGILState_Release(gstate);
+        Py_END_ALLOW_THREADS
 
         elapsedtime += waittime;
         waittime += 500 * tryn * tryn;
         tryn++;
     }
-	Py_END_ALLOW_THREADS
+
     return res;
 }
 

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -312,7 +312,7 @@ MILESTONE
                 return 0;
             }
 		}
-        sleep(4);
+        sleep(1);
         elapsedtime += waittime * 1000;
         waittime += tryn * tryn;
         tryn++;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -299,9 +299,8 @@ MILESTONE
     res = cpc_buf_remains();
     if (res) return res;
 
-    PyGILState_STATE gstate;
-    Py_BEGIN_ALLOW_THREADS
     while (1) {
+        Py_BEGIN_ALLOW_THREADS
 	    res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
         elapsedtime += 1000000; // read takes 1 sec from cefore-0.8.2.2
         if (res > 0) break;
@@ -316,7 +315,6 @@ MILESTONE
                 return 0;
             }
         }
-        gstate = PyGILState_Ensure();
         usleep(waittime);
         PyGILState_Release(gstate);
 

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -312,7 +312,7 @@ MILESTONE
                 return 0;
             }
 		}
-        sleep(waittime);
+        sleep(4);
         elapsedtime += waittime * 1000;
         waittime += tryn * tryn;
         tryn++;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -298,7 +298,7 @@ MILESTONE
     res = cpc_buf_remains();
     if (res) return res;
     while (1) {
-	res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
+	// res = cef_client_read(handler, buf, CefpycoC_Buffer_Size);
         elapsedtime += 1000000; // read takes 1 sec from cefore-0.8.2.2
         if (res > 0) break;
 	if (elapsedtime >= timeout_us) { // 13-tries take 1s, 18-tries take 4s

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -288,7 +288,7 @@ static int wait_receive(CefT_Client_Handle handler, int timeout_ms, int error_on
 MILESTONE
     int res = 0;
     int tryn = 0;
-    int waittime = 1000;
+    int waittime = 10;
     int elapsedtime = 0;
     int timeout_us;
 

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -312,7 +312,7 @@ MILESTONE
                 return 0;
             }
 		}
-        sleep(int(waittime/1000));
+        sleep((int) waittime/1000);
         elapsedtime += waittime;
         waittime += 500 * tryn * tryn;
         tryn++;

--- a/c_src/cefpyco.c
+++ b/c_src/cefpyco.c
@@ -314,10 +314,8 @@ MILESTONE
             	}
 	    }
 	    
-	    printf("%d\n", waittime);
-	    
 	    Py_BEGIN_ALLOW_THREADS
-	    sleep(1);
+	    usleep(waittime);
 	    Py_END_ALLOW_THREADS
 		    
 	    elapsedtime += waittime;


### PR DESCRIPTION
When CefpycoHandle.receive() is executed in a thread, blocking occurs and the program behaves as if it stopped for 4 seconds by default.

This is due to the wrapped C language.

Fixed so that python GIL works correctly.